### PR TITLE
Only reopen socket when it is not closed

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,10 @@ exports.connect = function (query, process, leid, endPoint) {
 
 
     function reopenSocket() {
+        // If the socket was closed, it should not be re-opened
+        if (!socket) {
+            return;
+        }
         socket.close();
         latestTxMatch = null;
         openSocket(lastEventId);


### PR DESCRIPTION
After running this in production for a while, I have been running across a few of these errors:

```js
TypeError: Cannot read property 'close' of null
    at reopenSocket (/home/bridgeport/bridgeport-ingestor/node_modules/bitsocket-connect/index.js:55:16)
    at Timeout._onTimeout (/home/bridgeport/bridgeport-ingestor/node_modules/bitsocket-connect/index.js:100:9)
    at listOnTimeout (internal/timers.js:555:17)
    at processTimers (internal/timers.js:498:7)
```

In theory, the `close` function should `clearInterval` every time, and `reopenSocket` should never be called while `socket` is `null`. I am not sure what the root cause of the error is (likely an issue with interval management if I had to take a guess), but this check would prevent the error.

Notably, in my use-case, I am starting and stopping multiple Bitsockets in an automated process as part of block processing, and the error does not appear to happen every time. It might just be an edge-case.